### PR TITLE
Fixes bug where the server was returning maximum products sold instea…

### DIFF
--- a/bangazon.session.sql
+++ b/bangazon.session.sql
@@ -22,3 +22,8 @@ JOIN
     auth_user seller
 ON 
     seller.id = Bang_C.user_id;
+
+SELECT 
+    *
+FROM 
+    bangazonapi_product bp;

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -268,7 +268,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
…d of minimum.

Description of PR that completes issue here...

## Changes

- Item 1: Conditional in product 'list' function that filters the numbers sold was set to 'less than' rather than 'greater than', which resulted in the server response returning all products that sold less than the number in the URL parameter instead of showing those that sold more than the specified number.

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET /products?number_sold=2 returns items that sold 2 or more times. The integer is interchangeable.

**Response**

HTTP/1.1" 200 196

```json
{
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
```

## Testing

Description of how to test code...

Make a GET request on Postman using the following URL:

http://localhost:8000/products?number_sold=2

## Related Issues

- Fixes #21 